### PR TITLE
Corrected the require statement to follow proper standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ that the user timer will be greater than the global timer.
                                                          :user   => 20 } }
 
 2. If you are using this with my plugins, things should just work. However if you want to use
-this with your own plugins, yoiu need to add a `require cinch/cooldown` to the top of said
+this with your own plugins, you need to add a `require cinch/cooldown` to the top of said
 plugin, and an `enforce_cooldown` to the plugin after the `include Cinch::Plugin` line.
 
 ## Contributing


### PR DESCRIPTION
Changed 'require cinch-cooldown' to 'require cinch/cooldown' as per http://guides.rubygems.org/name-your-gem/. The require not being able to find the gem threw me off for a while until i noticed that page. 

Also fixed a typo. :P
